### PR TITLE
♻️ Improve the import method of GPG keys on fish feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,9 @@ jobs:
       matrix:
         features: ${{ fromJSON(needs.detect-changes.outputs.features) }}
         baseImage:
-          - debian:stable-slim
+          - debian:9-slim
+          - debian:10-slim
+          - debian:11-slim
           - ubuntu:focal
           - ubuntu:jammy
           - mcr.microsoft.com/devcontainers/base:ubuntu
@@ -75,7 +77,9 @@ jobs:
         features:
           - fish
         baseImage:
-          - debian:stable-slim
+          - debian:9-slim
+          - debian:10-slim
+          - debian:11-slim
           - ubuntu:focal
           - ubuntu:jammy
           - mcr.microsoft.com/devcontainers/base:ubuntu

--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -60,7 +60,8 @@ fi
 echo "Installing fish shell..."
 source /etc/os-release
 if [ "${ID}" = "ubuntu" ]; then
-  apt-add-repository -y ppa:fish-shell/release-3
+  echo "deb https://ppa.launchpadcontent.net/fish-shell/release-3/ubuntu ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/shells:fish:release:3.list
+  curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x59fda1ce1b84b3fad89366c027557f056dc33ca5" | tee -a /etc/apt/trusted.gpg.d/shells_fish_release_3.asc > /dev/null
 elif [ "${ID}" = "debian" ]; then
   if [ "${VERSION_ID}" = "9" ]; then
     echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_9.0/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list

--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -51,7 +51,7 @@ check_packages() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies if missing
-check_packages curl ca-certificates gnupg2 apt-transport-https
+check_packages curl ca-certificates gnupg2
 if ! type git > /dev/null 2>&1; then
   check_packages git
 fi

--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -58,16 +58,17 @@ fi
 
 # Install fish shell
 echo "Installing fish shell..."
-if grep -q 'Ubuntu' < /etc/os-release; then
+source /etc/os-release
+if [ "${ID}" = "ubuntu" ]; then
   apt-add-repository -y ppa:fish-shell/release-3
-elif grep -q 'Debian' < /etc/os-release; then
-  if grep -q 'stretch' < /etc/os-release; then
+elif [ "${ID}" = "debian" ]; then
+  if [ "${VERSION_ID}" = "9" ]; then
     echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_9.0/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
     curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_9.0/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
-  elif grep -q 'buster' < /etc/os-release; then
+  elif [ "${VERSION_ID}" = "10" ]; then
     echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_10/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
     curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_10/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
-  elif grep -q 'bullseye' < /etc/os-release; then
+  elif [ "${VERSION_ID}" = "11" ]; then
     echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_11/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
     curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_11/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
   fi

--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -66,12 +66,9 @@ elif [ "${ID}" = "debian" ]; then
   if [ "${VERSION_ID}" = "9" ]; then
     echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_9.0/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
     curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_9.0/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
-  elif [ "${VERSION_ID}" = "10" ]; then
-    echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_10/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
-    curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_10/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
-  elif [ "${VERSION_ID}" = "11" ]; then
-    echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_11/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
-    curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_11/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+  else
+    echo "deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_${VERSION_ID}/ /" | tee /etc/apt/sources.list.d/shells:fish:release:3.list
+    curl -fsSL "https://download.opensuse.org/repositories/shells:fish:release:3/Debian_${VERSION_ID}/Release.key" | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
   fi
 fi
 apt-get update -y

--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -51,7 +51,7 @@ check_packages() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies if missing
-check_packages curl ca-certificates gnupg2
+check_packages curl ca-certificates
 if ! type git > /dev/null 2>&1; then
   check_packages git
 fi
@@ -65,10 +65,10 @@ if [ "${ID}" = "ubuntu" ]; then
 elif [ "${ID}" = "debian" ]; then
   if [ "${VERSION_ID}" = "9" ]; then
     echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_9.0/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
-    curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_9.0/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+    curl -fsSL "https://download.opensuse.org/repositories/shells:fish:release:3/Debian_9.0/Release.key" | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.asc > /dev/null
   else
     echo "deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_${VERSION_ID}/ /" | tee /etc/apt/sources.list.d/shells:fish:release:3.list
-    curl -fsSL "https://download.opensuse.org/repositories/shells:fish:release:3/Debian_${VERSION_ID}/Release.key" | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+    curl -fsSL "https://download.opensuse.org/repositories/shells:fish:release:3/Debian_${VERSION_ID}/Release.key" | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.asc > /dev/null
   fi
 fi
 apt-get update -y


### PR DESCRIPTION
This change simplifies the code and removes unnecessary dependencies.

This will also fix the problem of not being able to install the latest fish on Ubuntu.