### PR TITLE
🐛 Non-root user does not have Fisher installed when behind proxy

### DIFF
--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -81,7 +81,7 @@ if [ "${FISHER}" = "true" ]; then
   echo "Installing Fisher..."
   fish -c 'curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher'
   if [ "${USERNAME}" != "root" ]; then
-    sudo -u $USERNAME fish -c 'curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher'
+    su $USERNAME -c 'fish -c "curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher"'
   fi
   fish -c "fisher -v"
 fi


### PR DESCRIPTION
This change will also allow non-root users to install fisher even if sudo is not installed.