### PR TITLE
✨ Setup fish as default shell in VS Code

### DIFF
--- a/src/fish/devcontainer-feature.json
+++ b/src/fish/devcontainer-feature.json
@@ -10,5 +10,12 @@
       "default": true,
       "description": "Install Fisher plugin manager"
     }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "fish"
+      }
+    }
   }
 }


### PR DESCRIPTION
I think that if the developers install the fish feature, it is to use it.
Configuring vscode to set it as the default shell saves them from having to configure it themselves.