### PR TITLE
🚸 Install features after `common-utils`

### DIFF
--- a/src/fish/devcontainer-feature.json
+++ b/src/fish/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "fish",
   "id": "fish",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Installs fish shell and Fisher plugin manager (optionally)",
   "documentationURL": "https://github.com/meaningful-ooo/devcontainer-features/tree/main/src/fish",
   "options": {

--- a/src/fish/devcontainer-feature.json
+++ b/src/fish/devcontainer-feature.json
@@ -17,5 +17,8 @@
         "terminal.integrated.defaultProfile.linux": "fish"
       }
     }
-  }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/homebrew/devcontainer-feature.json
+++ b/src/homebrew/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Homebrew",
   "id": "homebrew",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Installs Homebrew",
   "documentationURL": "https://github.com/meaningful-ooo/devcontainer-features/tree/main/src/homebrew",
   "options": {

--- a/src/homebrew/devcontainer-feature.json
+++ b/src/homebrew/devcontainer-feature.json
@@ -18,5 +18,8 @@
     "PATH": "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}",
     "MANPATH": "/home/linuxbrew/.linuxbrew/share/man:${MANPATH}",
     "INFOPATH": "/home/linuxbrew/.linuxbrew/share/info:${INFOPATH}"
-  }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
 }


### PR DESCRIPTION
Since common-utils may be used to create a non-root user, it is better to run this Feature after creating the non-root user.

Note that this setting was applied to almost of https://github.com/devcontainers/features Features.