### PR TITLE
🔥 Remove redundant modifications of RC for Homebrew feature

### DIFF
--- a/src/homebrew/devcontainer-feature.json
+++ b/src/homebrew/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Homebrew",
   "id": "homebrew",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Installs Homebrew",
   "documentationURL": "https://github.com/meaningful-ooo/devcontainer-features/tree/main/src/homebrew",
   "options": {

--- a/src/homebrew/install.sh
+++ b/src/homebrew/install.sh
@@ -2,7 +2,6 @@
 
 BREW_PREFIX=${BREW_PREFIX:-"/home/linuxbrew/.linuxbrew"}
 SHALLOW_CLONE=${SHALLOW_CLONE:-"false"}
-UPDATE_RC="true"
 USERNAME=${USERNAME:-"automatic"}
 
 ARCHITECTURE="$(uname -m)"
@@ -138,13 +137,5 @@ fi
 mkdir "${BREW_PREFIX}/bin"
 ln -s "${BREW_PREFIX}/Homebrew/bin/brew" "${BREW_PREFIX}/bin"
 chown -R ${USERNAME} "${BREW_PREFIX}"
-
-# Add Homebrew binaries into PATH in bashrc/zshrc/config.fish files
-updaterc "$(cat << EOF
-if [[ "\${PATH}" != *"${BREW_PREFIX}/bin"* ]]; then export PATH="${BREW_PREFIX}/bin:\${PATH}"; fi
-if [[ "\${PATH}" != *"${BREW_PREFIX}/sbin"* ]]; then export PATH="${BREW_PREFIX}/sbin:\${PATH}"; fi
-EOF
-)"
-updatefishconfig "fish_add_path ${BREW_PREFIX}/bin ${BREW_PREFIX}/sbin"
 
 echo "Done!"


### PR DESCRIPTION
Since we use `containerEnv` property, modifying RC to update `PATH` is redundant.