### PR TITLE
🐛 Disable Homebrew auto update when installed alongside fish feature

### DIFF
--- a/src/homebrew/devcontainer-feature.json
+++ b/src/homebrew/devcontainer-feature.json
@@ -20,6 +20,7 @@
     "INFOPATH": "/home/linuxbrew/.linuxbrew/share/info:${INFOPATH}"
   },
   "installsAfter": [
-    "ghcr.io/devcontainers/features/common-utils"
+    "ghcr.io/devcontainers/features/common-utils",
+    "ghcr.io/meaningful-ooo/devcontainer-features/fish"
   ]
 }

--- a/src/homebrew/devcontainer-feature.json
+++ b/src/homebrew/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Homebrew",
   "id": "homebrew",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Installs Homebrew",
   "documentationURL": "https://github.com/meaningful-ooo/devcontainer-features/tree/main/src/homebrew",
   "options": {


### PR DESCRIPTION
Since Homebrew feature modifies `config.fish` if `shallowClone` option is used, make sure to install it after the fish feature.