### PR TITLE
🧪 Update Debian tags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,9 +37,9 @@ jobs:
         baseImage:
           - mcr.microsoft.com/devcontainers/base:debian
           - mcr.microsoft.com/devcontainers/base:ubuntu
-          - debian:9-slim
-          - debian:10-slim
-          - debian:11-slim
+          - debian:oldoldstable-slim
+          - debian:oldstable-slim
+          - debian:stable-slim
           - ubuntu:focal
           - ubuntu:jammy
     steps:
@@ -81,9 +81,9 @@ jobs:
         baseImage:
           - mcr.microsoft.com/devcontainers/base:debian
           - mcr.microsoft.com/devcontainers/base:ubuntu
-          - debian:9-slim
-          - debian:10-slim
-          - debian:11-slim
+          - debian:oldoldstable-slim
+          - debian:oldstable-slim
+          - debian:stable-slim
           - ubuntu:focal
           - ubuntu:jammy
     steps:


### PR DESCRIPTION
I noticed that Debian 12 is not on the matrix.