### PR TITLE
🐛 Fish install to fail if something fails

### DIFF
--- a/src/fish/devcontainer-feature.json
+++ b/src/fish/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "fish",
   "id": "fish",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Installs fish shell and Fisher plugin manager (optionally)",
   "documentationURL": "https://github.com/meaningful-ooo/devcontainer-features/tree/main/src/fish",
   "options": {

--- a/src/fish/install.sh
+++ b/src/fish/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 FISHER=${FISHER:-"true"}
 USERNAME=${USERNAME:-"automatic"}
 


### PR DESCRIPTION
In case fish install fails, the install.sh script will now fail. This is to ensure that the devcontainer is not left in a broken state and that a failed install does not end up being cached in Docker layer making it difficult to recover from.

Fixes #55 